### PR TITLE
Fix compilation with on Ubuntu 22.04

### DIFF
--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -126,7 +126,7 @@ if (dir.exists(debian_local)) {
 message("*** compiling proto files ...")
 system(
 	sprintf(
-		"%s %s --cpp_out=./src %s",
+		"%s %s --cpp_out=./src --experimental_allow_proto3_optional %s",
 		protoc,
 		paste0("-I=", ipath, collapse = " "),
 		paste(protos, collapse = " ")))


### PR DESCRIPTION
Without this you get
```
*** compiling proto files ...
google/cloud/bigquery/storage/v1/stream.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.
*** searching for pkg-config ... OK
```
...
```
make: *** No rule to make target 'google/api/field_behavior.pb.o', needed by 'bigrquerystorage.so'.  Stop.
ERROR: compilation failed for package ‘bigrquerystorage’
```