### PR TITLE
Fix build on Windows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^LICENSE\.md$
 ^[.]deps$
 ^[.]deps-arm64$
+^[.]deps-win$
+^inst/roots[.]pem$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,6 +82,8 @@ jobs:
       - name: "Update Rtools43 on Windows (temporary)"
         if: runner.os == 'Windows'
         run: |
+          mv c:\rtools43 c:\rtools43-old
+          mkdir c:\rtools43
           rig rm rtools43
           rig add rtools43
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -92,10 +92,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - run: |
-          R.exe CMD INSTALL .
-
       - uses: r-lib/actions/check-r-package@v2
-        if: false
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # this is too slow
-          # - { os: macos-11,       r: 'release' }
+          - { os: macos-11,       r: 'release' }
           - { os: macos-12,       r: 'release' }
           - { os: macos-13,       r: 'release' }
-          - { os: macos-11,       r: 'release', deps: true }
+          # this is too slow
+          # - { os: macos-11,       r: 'release', deps: true }
           - { os: macos-12,       r: 'release', deps: true }
           - { os: macos-13,       r: 'release', deps: true }
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,9 @@ jobs:
           - { os: macos-12,       r: 'release', deps: true }
           - { os: macos-13,       r: 'release', deps: true }
 
-          # - {os: windows-latest, r: 'release'}
+          - { os: windows-latest, r: 'release' }
+          - { os: windows-latest, r: 'devel'   }
+
           # Use 3.6 to trigger usage of RTools35
           # - {os: windows-latest, r: '3.6'}
           # use 4.1 to check with rtools40's older compiler

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,12 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # this is too slow
           # - { os: macos-11,       r: 'release' }
-          # - { os: macos-12,       r: 'release' }
-          # - { os: macos-13,       r: 'release' }
-          # - { os: macos-11,       r: 'release', deps: true }
-          # - { os: macos-12,       r: 'release', deps: true }
-          # - { os: macos-13,       r: 'release', deps: true }
+          - { os: macos-12,       r: 'release' }
+          - { os: macos-13,       r: 'release' }
+          - { os: macos-11,       r: 'release', deps: true }
+          - { os: macos-12,       r: 'release', deps: true }
+          - { os: macos-13,       r: 'release', deps: true }
 
           - { os: windows-latest, r: 'release' }
           - { os: windows-latest, r: 'devel'   }
@@ -37,12 +38,12 @@ jobs:
           # use 4.1 to check with rtools40's older compiler
           # - {os: windows-latest, r: '4.1'}
 
-          # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          # - { os: ubuntu-latest,  r: 'release'  }
-          # - { os: ubuntu-latest,  r: 'oldrel-1' }
-          # - { os: ubuntu-latest,  r: 'oldrel-2' }
-          # - { os: ubuntu-latest,  r: 'oldrel-3' }
-          # - { os: ubuntu-latest,  r: 'oldrel-4' }
+          - { os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - { os: ubuntu-latest,  r: 'release'  }
+          - { os: ubuntu-latest,  r: 'oldrel-1' }
+          - { os: ubuntu-latest,  r: 'oldrel-2' }
+          - { os: ubuntu-latest,  r: 'oldrel-3' }
+          - { os: ubuntu-latest,  r: 'oldrel-4' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -74,11 +74,26 @@ jobs:
         run: |
           brew install grpc pkg-config
 
+      - name: "Install rig on Windows (temporary)"
+        if: runner.os == 'Windows'
+        run: |
+          choco install rig
+
+      - name: "Update Rtools43 on Windows (temporary)"
+        if: runner.os == 'Windows'
+        run: |
+          rig rm rtools43
+          rig add rtools43
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - run: |
+          R.exe CMD INSTALL .
+
       - uses: r-lib/actions/check-r-package@v2
+        if: false
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,12 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-11,       r: 'release' }
-          - { os: macos-12,       r: 'release' }
-          - { os: macos-13,       r: 'release' }
-          - { os: macos-11,       r: 'release', deps: true }
-          - { os: macos-12,       r: 'release', deps: true }
-          - { os: macos-13,       r: 'release', deps: true }
+          # - { os: macos-11,       r: 'release' }
+          # - { os: macos-12,       r: 'release' }
+          # - { os: macos-13,       r: 'release' }
+          # - { os: macos-11,       r: 'release', deps: true }
+          # - { os: macos-12,       r: 'release', deps: true }
+          # - { os: macos-13,       r: 'release', deps: true }
 
           - { os: windows-latest, r: 'release' }
           - { os: windows-latest, r: 'devel'   }
@@ -38,11 +38,11 @@ jobs:
           # - {os: windows-latest, r: '4.1'}
 
           # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - { os: ubuntu-latest,  r: 'release'  }
-          - { os: ubuntu-latest,  r: 'oldrel-1' }
-          - { os: ubuntu-latest,  r: 'oldrel-2' }
-          - { os: ubuntu-latest,  r: 'oldrel-3' }
-          - { os: ubuntu-latest,  r: 'oldrel-4' }
+          # - { os: ubuntu-latest,  r: 'release'  }
+          # - { os: ubuntu-latest,  r: 'oldrel-1' }
+          # - { os: ubuntu-latest,  r: 'oldrel-2' }
+          # - { os: ubuntu-latest,  r: 'oldrel-3' }
+          # - { os: ubuntu-latest,  r: 'oldrel-4' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/google/
 /src/Makevars
 /.deps
 /.deps-arm64
+/.deps-win
+/inst/roots.pem

--- a/R/onload.R
+++ b/R/onload.R
@@ -1,0 +1,11 @@
+.onLoad <- function(libname, pkgname) {
+  # On Windows, we might have an embedded SLL root cert file.
+  # Externally env var, set by the user, takes priority.
+  if (.Platform$OS.type == "windows") {
+    pem <- system.file(package = .packageName, "roots.pem")
+    if (pem != "" && file.exists(pem) &&
+        Sys.getenv("GRPC_DEFAULT_SSL_ROOTS_FILE_PATH") == "") {
+      Sys.setenv("GRPC_DEFAULT_SSL_ROOTS_FILE_PATH" = normalizePath(pem))
+    }
+  }
+}

--- a/tools/config.R
+++ b/tools/config.R
@@ -111,7 +111,7 @@ configure_file <- function(
 
     # write configured file to target location
     # prefer unix newlines for Makevars
-    mode <- if (target %in% "Makevars") "wb" else "w"
+    mode <- if (target %in% "Makevars") "wb" else "wb"
     conn <- file(target, open = mode)
     on.exit(close(conn), add = TRUE)
     writeLines(contents, con = conn)

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -8,17 +8,6 @@ source("tools/config/functions.R")
 win <- .Platform$OS.type == "windows"
 mac <- Sys.info()[["sysname"]] == "Darwin"
 
-print(dir("C:/rtools43/x86_64-w64-mingw32.static.posix/bin"))
-print(Sys.getenv("PATH"))
-print(Sys.which("pkgconf"))
-print(Sys.which("pkgconf.exe"))
-system("pkgconf --version")
-system("pkg-config --version")
-system("sh -c 'pkgconf --version'")
-system("sh -c 'pkg-config --version'")
-writeLines(readLines("C:/rtools43/x86_64-w64-mingw32.static.posix/.version"))
-writeLines(readLines("C:/rtools43/x86_64-w64-mingw32.static.posix/installed.list"))
-
 # System requirements -----------------------------------------------------
 
 done <- FALSE

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -205,6 +205,22 @@ fix_flags <- function(x) {
   x
 }
 
+# On Windows, we need to replace CRLF line endings with LF,
+# otherwise `R CMD check` will complain. We also make sure that they
+# end with a newline, again to fix `R CMD check`.
+if (win) {
+  src <- file.path("src", "google", dir(
+    file.path("src", "google"),
+    pattern = "[.]pb[.](h|cc)$",
+    recursive = TRUE
+  ))
+  for (fn in src) {
+    lns <- readLines(fn)
+    bts <- charToRaw(paste0(c(lns, ""), collapse = "\n"))
+    writeBin(bts, fn)
+  }
+}
+
 # define variable for template
 define(CPPF = fix_flags(paste(cflags, "-DSTRING_R_HEADERS", "-I.")))
 define(CXXF = cxxflags)

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -8,10 +8,6 @@ source("tools/config/functions.R")
 win <- .Platform$OS.type == "windows"
 mac <- Sys.info()[["sysname"]] == "Darwin"
 
-sys <- function(cmd, intern = TRUE, ...) {
-  as_string(suppressWarnings(system(cmd, intern = intern, ...)))
-}
-
 # System requirements -----------------------------------------------------
 
 done <- FALSE
@@ -42,7 +38,14 @@ if (!done && mac && Sys.getenv("DISABLE_AUTOBREW") == "") {
   if (done) config_from <- "autobrew"
 }
 
-# TODO: download static libs on windows
+if (win) {
+  download_win()
+  flags <- configure_win()
+  cflags <- as_string(flags$cflags)
+  ldflags <- as_string(flags$ldflags)
+  done <- nzchar(cflags) || nzchar(ldflags)
+  if (done) config_from <- "winlib"
+}
 
 # give up
 # TODO: better error message, suggest solutions
@@ -111,7 +114,8 @@ protos <- compile_order(services, base_proto_path)
 # protos include path (to locate google/protobuf/*.proto)
 ipath <- c(
   base_proto_path,
-  if (config_from == "autobrew") autobrew_proto_include_path
+  if (config_from == "autobrew") autobrew_proto_include_path,
+  if (config_from == "winlib") winlib_proto_include_path
 )
 
 # compile proto files to generate basic grpc client
@@ -169,7 +173,9 @@ for (src_ in gle_cc) {
   src <- file.path("src", "google", src_)
   lns <- c(
     "# pragma GCC diagnostic ignored \"-Wdeprecated-declarations\"",
-    "# pragma GCC diagnostic ignored \"-Winconsistent-missing-override\"",
+    if (!win) {
+      "# pragma GCC diagnostic ignored \"-Winconsistent-missing-override\""
+    },
     readLines(src)
   )
   lns <- sub("^#pragma ", "# pragma ", lns)

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -8,6 +8,17 @@ source("tools/config/functions.R")
 win <- .Platform$OS.type == "windows"
 mac <- Sys.info()[["sysname"]] == "Darwin"
 
+print(dir("C:/rtools43/x86_64-w64-mingw32.static.posix/bin"))
+print(Sys.getenv("PATH"))
+print(Sys.which("pkgconf"))
+print(Sys.which("pkgconf.exe"))
+system("pkgconf --version")
+system("pkg-config --version")
+system("sh -c 'pkgconf --version'")
+system("sh -c 'pkg-config --version'")
+writeLines(readLines("C:/rtools43/x86_64-w64-mingw32.static.posix/.version"))
+writeLines(readLines("C:/rtools43/x86_64-w64-mingw32.static.posix/installed.list"))
+
 # System requirements -----------------------------------------------------
 
 done <- FALSE

--- a/tools/config/functions.R
+++ b/tools/config/functions.R
@@ -91,7 +91,7 @@ configure_autobrew <- function() {
     "INSTALL_RECEIPT.json"
   )
   # we only need to replace @@HOMEBREW_CELLAR@@
-  cellar <- file.path(getwd(), path)
+  cellar <- file.path(normalizePath(path))
   for (js in rcpt) {
     lns <- readLines(js, warn = FALSE)
     from <- grep("changed_files", lns)[1] + 1L

--- a/tools/config/functions.R
+++ b/tools/config/functions.R
@@ -151,7 +151,11 @@ download_win <- function() {
 
 configure_win <- function() {
   Sys.setenv("PKG_CONFIG_PATH" = normalizePath(winlib_pkg_config_path))
+  print(Sys.getenv("PATH"))
   add_to_path(winlib_bin)
+  print(Sys.getenv("PATH"))
+  print(Sys.which("pkg-config"))
+  print(Sys.which("pkgconf"))
   list(
     cflags = sys(
       "pkgconf --cflags --silence-errors grpc++ protobuf"


### PR DESCRIPTION
Mostly straightforward, and I left some comments in the code that hopefully explain the motivation for some of the more obscure bits. 

The cross compiling of grpc breaks the loading of the grpc root certificates, so we embed them into the package on Windows, and set an env var at load time to point to it.
