### PR TITLE
Improve installation advice in configure for Linux

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -53,8 +53,7 @@ remotes::install_github("meztez/bigrquerystorage")
 
 ```sh
 # install protoc and grpc
-apt-get install -y libprotobuf-dev protobuf-compiler-grpc \
-                   libgrpc++-dev libc-ares-dev libre2-dev \
+apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
                    pkg-config
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,10 +60,8 @@ apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
 #### Fedora 38
 
 ```sh
-# install protoc and grpc
-dnf install -y protobuf-devel protobuf-compiler \
-               grpc-devel c-ares-devel \
-               re2-devel pkgconf
+# install grpc, protoc is automatically installed
+dnf install -y grpc-devel pkgconf
 ```
 
 #### macOS

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ remotes::install_github("meztez/bigrquerystorage")
 
 ``` sh
 # install protoc and grpc
-apt-get install -y libprotobuf-dev protobuf-compiler-grpc \
-                   libgrpc++-dev libc-ares-dev libre2-dev \
+apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
                    pkg-config
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
 #### Fedora 38
 
 ``` sh
-# install protoc and grpc
-dnf install -y protobuf-devel protobuf-compiler \
-               grpc-devel c-ares-devel \
-               re2-devel pkgconf
+# install grpc, protoc is automatically installed
+dnf install -y grpc-devel pkgconf
 ```
 
 #### macOS

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@
 # Library settings
 PKG_CONFIG_NAME="protobuf grpc++"
 PKG_DEB_NAME="libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc pkg-config"
-PKG_RPM_NAME="protobuf-devel protobuf-compiler grpc-devel c-ares-devel re2-devel pkgconf"
+PKG_RPM_NAME="grpc-devel pkgconf"
 PKG_BREW_NAME="grpc pkg-config"
 PKG_TEST_HEADER="<grpc/grpc.h>"
 PKG_LIBS="-lgrpc++ -lgrpc -lprotobuf"

--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@
 
 # Library settings
 PKG_CONFIG_NAME="protobuf grpc++"
-PKG_DEB_NAME="libprotobuf-dev protobuf-compiler-grpc libgrpc++-dev libc-ares-dev libre2-dev pkg-config"
+PKG_DEB_NAME="libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc pkg-config"
 PKG_RPM_NAME="protobuf-devel protobuf-compiler grpc-devel c-ares-devel re2-devel pkgconf"
 PKG_BREW_NAME="grpc pkg-config"
 PKG_TEST_HEADER="<grpc/grpc.h>"

--- a/configure
+++ b/configure
@@ -6,9 +6,9 @@
 
 # Library settings
 PKG_CONFIG_NAME="protobuf grpc++"
-PKG_DEB_NAME="libgrpc-dev"
-PKG_RPM_NAME="grpc-devel"
-PKG_BREW_NAME="grpc"
+PKG_DEB_NAME="libprotobuf-dev protobuf-compiler-grpc libgrpc++-dev libc-ares-dev libre2-dev pkg-config"
+PKG_RPM_NAME="protobuf-devel protobuf-compiler grpc-devel c-ares-devel re2-devel pkgconf"
+PKG_BREW_NAME="grpc pkg-config"
 PKG_TEST_HEADER="<grpc/grpc.h>"
 PKG_LIBS="-lgrpc++ -lgrpc -lprotobuf"
 PKG_CFLAGS=""

--- a/tools/build/linux/Dockerfile-debian-12
+++ b/tools/build/linux/Dockerfile-debian-12
@@ -13,18 +13,17 @@ RUN echo "deb http://rig.r-pkg.org/deb rig main" > \
     rig add release
 
 # -------------------------------------------------------------------------
-# FIXME: We don't need this once grpc is in the system requirements db
-RUN apt-get install -y libprotobuf-dev protobuf-compiler-grpc \
-                       libgrpc++-dev libc-ares-dev \
-                       libre2-dev pkg-config
-
-# -------------------------------------------------------------------------
 # Only copy DESCRIPTION, so Docker can cache the dependency install
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
 # No upgrade, to always install binary packages, in case P3M is behind
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+                       pkg-config
 
 # -------------------------------------------------------------------------
 # Call R CMD build first, so we get rid of Makevars, .o, .so, etc.

--- a/tools/build/linux/Dockerfile-fedora-38
+++ b/tools/build/linux/Dockerfile-fedora-38
@@ -8,18 +8,16 @@ RUN yum install -y \
     rig add devel
 
 # -------------------------------------------------------------------------
-# FIXME: We don't need this once grpc is in the system requirements db
-RUN dnf install -y protobuf-devel protobuf-compiler \
-                   grpc-devel c-ares-devel \
-                   re2-devel pkgconf
-
-# -------------------------------------------------------------------------
 # Only copy DESCRIPTION, so Docker can cache the dependency install
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
 # No upgrade, to always install binary packages, in case P3M is behind
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN dnf install -y grpc-devel pkgconf
 
 # -------------------------------------------------------------------------
 # Call R CMD build first, so we get rid of Makevars, .o, .so, etc.

--- a/tools/build/linux/Dockerfile-ubuntu-22.04
+++ b/tools/build/linux/Dockerfile-ubuntu-22.04
@@ -13,18 +13,17 @@ RUN echo "deb http://rig.r-pkg.org/deb rig main" > \
     rig add release
 
 # -------------------------------------------------------------------------
-# FIXME: We don't need this once grpc is in the system requirements db
-RUN apt-get install -y libprotobuf-dev protobuf-compiler-grpc \
-                       libgrpc++-dev libc-ares-dev libre2-dev \
-                       pkg-config
-
-# -------------------------------------------------------------------------
 # Only copy DESCRIPTION first, so Docker can cache the dependency install
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
 # No upgrade, to always install binary packages, in case P3M is behind
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+                       pkg-config
 
 # -------------------------------------------------------------------------
 # Call R CMD build first, so we get rid of Makevars, .o, .so, etc.


### PR DESCRIPTION
Installing libgrpc-dev is not enough, unfortunately. I think for some of these packages it is enough the library, and the `-dev` package is not needed, but then we need to consider that the library packages have different names on different distro versions, so it is simpler to list the `-dev` package.