### PR TITLE
More Linux distros to test on GHA

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -4,64 +4,44 @@ name: Linux build test
 on:
   workflow_dispatch:
     inputs:
-      ubuntu-2204:
-        description: "Ubuntu 22.04"
-        required: true
-        type: choice
-        options:
-        - 'yes'
-        - 'no'
-        default: 'yes'
-      debian-12:
-        description: "Debian 12"
-        required: true
-        type: choice
-        options:
-        - 'yes'
-        - 'no'
-        default: 'yes'
-      fedora-38:
-        description: "Fedora 38"
-        required: true
-        type: choice
-        options:
-        - 'yes'
-        - 'no'
-        default: 'yes'
+      distros:
+        description: |
+          Distros, default is all, possible values: alpine-3.16,
+          alpine-3.17, alpine-3.18, alpine-3.19, alpine-edge, debian-10,
+          debian-11, debian-12, debian-unstable, fedora-36, fedora-37,
+          fedora-38, rocky-9, ubuntu-22.04.
+        required: false
+        defaule: 'all'
+        type: strinf
 
 jobs:
-  ubuntu-2204:
-    if: ${{ github.event.inputs.ubuntu-2204 == '' || github.event.inputs.ubuntu-2204 == 'yes' }}
-    runs-on: ubuntu-latest
-    name: Ubuntu 22.04
+  setup-matrix:
+    runs-on: ubuntu-Latest
+    outputs:
+      distros: ${{ steps.setup-matrix.outputs.distros }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Build in Docker
+    - uses: actions/checkout@v3
+    - name: Set up matrix of builds
+      id: setup-matrix
       run: |
-        docker build -f tools/build/linux/Dockerfile-ubuntu-22.04 -t bqs:ubuntu2204 .
-        docker run bqs:ubuntu2204 R -q -e 'library(bigrquerystorage)'
+        distros=$(python tools/build/linux/get-distros.py "${{ github.event.inputs.distros }}")
+        echo "distros=$distros" >> $GITHUB_OUTPUT
 
-  debian-12:
-    if: ${{ github.event.inputs.debian-12 == '' || github.event.inputs.debian-12 == 'yes' }}
-    runs-on: ubuntu-latest
-    name: Debian 12
+  build:
+    needs: setup-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ${{ fromJson(needs.setup-matrix.outputs.distros) }}
+    runs-on: ubuntu-Latest
+    name: ${{ matrix.distro }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Build in Docker
-      run: |
-        docker build -f tools/build/linux/Dockerfile-debian-12 -t bqs:debian12 .
-        docker run bqs:debian12 R -q -e 'library(bigrquerystorage)'
+    - uses: actions/checkout@v3
 
-  fedora-38:
-    if: ${{ github.event.inputs.fedora-38 == '' || github.event.inputs.fedora-38 == 'yes' }}
-    runs-on: ubuntu-latest
-    name: Fedora 38
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Build in Docker
+    - name: Build package
       run: |
-        docker build -f tools/build/linux/Dockerfile-fedora-38 -t bqs:fedora-38 .
-        docker run bqs:fedora-38 R -q -e 'library(bigrquerystorage)'
+        docker build -f tools/build/linux/Dockerfile-${{ matrix.distro }} -t bqs:${{ matrix.distro }} .
+
+    - name: Test loading package
+      run: |
+        docker run bqs:${{ matrix.distro }} R -q -e 'library(bigrquerystorage)'

--- a/tools/build/linux/Dockerfile-alpine-3.16
+++ b/tools/build/linux/Dockerfile-alpine-3.16
@@ -1,0 +1,32 @@
+# -*- Dockerfile -*-
+
+FROM alpine:3.16
+
+# -------------------------------------------------------------------------
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN apk del openssl-dev
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apk add grpc-dev protobuf-dev re2-dev c-ares-dev
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-alpine-3.16
+++ b/tools/build/linux/Dockerfile-alpine-3.16
@@ -3,7 +3,8 @@
 FROM alpine:3.16
 
 # -------------------------------------------------------------------------
-RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git cmake bash \
+            linux-headers
 RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 
 # -------------------------------------------------------------------------
@@ -11,8 +12,9 @@ RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
+RUN mkdir -p ~/.R && echo "LDFLAGS+=-fPIC" >> ~/.R/Makevars
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
-RUN apk del openssl-dev
+RUN apk del openssl-dev cmake linux-headers
 
 # -------------------------------------------------------------------------
 # FIXME: We don't need this once grpc is in the system requirements db

--- a/tools/build/linux/Dockerfile-alpine-3.17
+++ b/tools/build/linux/Dockerfile-alpine-3.17
@@ -3,7 +3,8 @@
 FROM alpine:3.17
 
 # -------------------------------------------------------------------------
-RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git cmake bash \
+            linux-headers
 RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 
 # -------------------------------------------------------------------------
@@ -11,8 +12,9 @@ RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
+RUN mkdir -p ~/.R && echo "LDFLAGS+=-fPIC" >> ~/.R/Makevars
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
-RUN apk del openssl-dev
+RUN apk del openssl-dev cmake linux-headers
 
 # -------------------------------------------------------------------------
 # FIXME: We don't need this once grpc is in the system requirements db

--- a/tools/build/linux/Dockerfile-alpine-3.17
+++ b/tools/build/linux/Dockerfile-alpine-3.17
@@ -1,0 +1,32 @@
+# -*- Dockerfile -*-
+
+FROM alpine:3.17
+
+# -------------------------------------------------------------------------
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN apk del openssl-dev
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apk add grpc-dev protobuf-dev re2-dev c-ares-dev
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-alpine-3.18
+++ b/tools/build/linux/Dockerfile-alpine-3.18
@@ -1,0 +1,32 @@
+# -*- Dockerfile -*-
+
+FROM alpine:3.18
+
+# -------------------------------------------------------------------------
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN apk del openssl-dev
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apk add grpc-dev protobuf-dev
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-alpine-3.18
+++ b/tools/build/linux/Dockerfile-alpine-3.18
@@ -3,7 +3,8 @@
 FROM alpine:3.18
 
 # -------------------------------------------------------------------------
-RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git cmake bash \
+            linux-headers
 RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 
 # -------------------------------------------------------------------------
@@ -11,8 +12,9 @@ RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
+RUN mkdir -p ~/.R && echo "LDFLAGS+=-fPIC" >> ~/.R/Makevars
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
-RUN apk del openssl-dev
+RUN apk del openssl-dev cmake linux-headers
 
 # -------------------------------------------------------------------------
 # FIXME: We don't need this once grpc is in the system requirements db

--- a/tools/build/linux/Dockerfile-alpine-3.19
+++ b/tools/build/linux/Dockerfile-alpine-3.19
@@ -3,7 +3,8 @@
 FROM alpine:3.19
 
 # -------------------------------------------------------------------------
-RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git cmake bash \
+            linux-headers
 RUN R -q -e 'source("https://pak.r-lib.org/install.R"); library(pak)'
 
 # -------------------------------------------------------------------------
@@ -11,8 +12,9 @@ RUN R -q -e 'source("https://pak.r-lib.org/install.R"); library(pak)'
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
+RUN mkdir -p ~/.R && echo "LDFLAGS+=-fPIC" >> ~/.R/Makevars
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
-RUN apk del openssl-dev
+RUN apk del openssl-dev cmake linux-headers
 
 # -------------------------------------------------------------------------
 # FIXME: We don't need this once grpc is in the system requirements db

--- a/tools/build/linux/Dockerfile-alpine-3.19
+++ b/tools/build/linux/Dockerfile-alpine-3.19
@@ -1,0 +1,32 @@
+# -*- Dockerfile -*-
+
+FROM alpine:3.19
+
+# -------------------------------------------------------------------------
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN R -q -e 'source("https://pak.r-lib.org/install.R"); library(pak)'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN apk del openssl-dev
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apk add grpc-dev protobuf-dev re2-dev c-ares-dev
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-alpine-edge
+++ b/tools/build/linux/Dockerfile-alpine-edge
@@ -3,7 +3,8 @@
 FROM alpine:edge
 
 # -------------------------------------------------------------------------
-RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git cmake bash \
+            linux-headers
 RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 
 # -------------------------------------------------------------------------
@@ -11,8 +12,9 @@ RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
 RUN mkdir /root/bigrquerystorage
 COPY DESCRIPTION /root/bigrquerystorage/
 WORKDIR /root/bigrquerystorage
+RUN mkdir -p ~/.R && echo "LDFLAGS+=-fPIC" >> ~/.R/Makevars
 RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
-RUN apk del openssl-dev
+RUN apk del openssl-dev cmake linux-headers
 
 # -------------------------------------------------------------------------
 # FIXME: We don't need this once grpc is in the system requirements db

--- a/tools/build/linux/Dockerfile-alpine-edge
+++ b/tools/build/linux/Dockerfile-alpine-edge
@@ -1,0 +1,32 @@
+# -*- Dockerfile -*-
+
+FROM alpine:edge
+
+# -------------------------------------------------------------------------
+RUN apk add R R-dev g++ gcc make openssl openssl-dev git
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN apk del openssl-dev
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apk add grpc-dev protobuf-dev re2-dev c-ares-dev
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-debian-10
+++ b/tools/build/linux/Dockerfile-debian-10
@@ -1,0 +1,46 @@
+# -*- Dockerfile -*-
+
+FROM debian:10
+
+# -------------------------------------------------------------------------
+# This is going to use P3M on x86_64
+COPY tools/build/linux/rig.gpg /etc/apt/trusted.gpg.d/rig.gpg
+RUN echo "deb http://rig.r-pkg.org/deb rig main" > \
+        /etc/apt/sources.list.d/rig.list && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && \
+    apt-get install -y r-rig && \
+    rig add release
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN echo "deb https://deb.debian.org/debian buster-backports main" >> \
+    /etc/apt/sources.list.d/backports.list && \
+    apt-get update
+RUN apt-get update && \
+    apt-get install -y 'libgrpc\+\+-dev'/buster-backports \
+                       protobuf-compiler-grpc/buster-backports \
+                       libprotobuf-dev/buster-backports \
+                       protobuf-compiler/buster-backports pkg-config
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN apt-get install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-debian-11
+++ b/tools/build/linux/Dockerfile-debian-11
@@ -1,0 +1,40 @@
+# -*- Dockerfile -*-
+
+FROM debian:11
+
+# -------------------------------------------------------------------------
+# This is going to use P3M on x86_64
+COPY tools/build/linux/rig.gpg /etc/apt/trusted.gpg.d/rig.gpg
+RUN echo "deb http://rig.r-pkg.org/deb rig main" > \
+        /etc/apt/sources.list.d/rig.list && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && \
+    apt-get install -y r-rig && \
+    rig add release
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+                       pkg-config
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN apt-get install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-debian-unstable
+++ b/tools/build/linux/Dockerfile-debian-unstable
@@ -1,0 +1,37 @@
+# -*- Dockerfile -*-
+
+FROM debian:unstable
+
+# -------------------------------------------------------------------------
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && \
+    apt-get install -y r-base
+
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN apt-get install -y libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+                       pkg-config
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN apt-get install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-fedora-36
+++ b/tools/build/linux/Dockerfile-fedora-36
@@ -1,0 +1,33 @@
+# -*- Dockerfile -*-
+
+FROM fedora:36
+
+# -------------------------------------------------------------------------
+RUN yum install -y R-devel
+RUN R -q -e 'source("https://pak.r-lib.org/install.R")'
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN dnf install -y grpc-devel pkgconf
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN dnf install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-fedora-37
+++ b/tools/build/linux/Dockerfile-fedora-37
@@ -1,0 +1,34 @@
+# -*- Dockerfile -*-
+
+FROM fedora:37
+
+# -------------------------------------------------------------------------
+RUN yum install -y \
+        https://github.com/r-lib/rig/releases/download/latest/r-rig-latest-1.$(arch).rpm && \
+    rig add devel
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN dnf install -y grpc-devel pkgconf
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN dnf install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/Dockerfile-rocky-9
+++ b/tools/build/linux/Dockerfile-rocky-9
@@ -1,0 +1,36 @@
+# -*- Dockerfile -*-
+
+FROM rockylinux:9
+
+# -------------------------------------------------------------------------
+RUN yum install -y \
+        https://github.com/r-lib/rig/releases/download/latest/r-rig-latest-1.$(arch).rpm && \
+    rig add release
+
+# -------------------------------------------------------------------------
+# Only copy DESCRIPTION, so Docker can cache the dependency install
+RUN mkdir /root/bigrquerystorage
+COPY DESCRIPTION /root/bigrquerystorage/
+WORKDIR /root/bigrquerystorage
+# No upgrade, to always install binary packages, in case P3M is behind
+RUN yum install -y openssl-devel openssl
+RUN R -q -e 'pak::local_install_deps(upgrade = FALSE)'
+RUN yum remove -y openssl-devel
+
+# -------------------------------------------------------------------------
+# FIXME: We don't need this once grpc is in the system requirements db
+RUN dnf install -y grpc-devel pkgconf
+
+# -------------------------------------------------------------------------
+# Call R CMD build first, so we get rid of Makevars, .o, .so, etc.
+# Change file ownership, otherwise git complains
+# Clean up thoroughly, in case the cleanup script is not perfect.
+RUN dnf install -y git
+COPY . /root/bigrquerystorage
+RUN chown root:root -R .
+RUN git clean -fdx .
+
+# -------------------------------------------------------------------------
+WORKDIR /root
+RUN R CMD build bigrquerystorage
+RUN R CMD INSTALL bigrquerystorage_*.tar.gz

--- a/tools/build/linux/get-distros.py
+++ b/tools/build/linux/get-distros.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import argparse
+
+parser = argparse.ArgumentParser(description="Print distros as JSON.")
+parser.add_argument(
+    'distros',
+    type = str,
+    nargs = '?',
+    default = 'all',
+    help = 'Comma-separated list of distros. Default is "all" to use all distros.'
+)
+args = parser.parse_args()
+
+conts = os.listdir("tools/build/linux")
+dfs = [ x for x in conts if x.startswith("Dockerfile-") ]
+distros = [ x.replace("Dockerfile-", "") for x in dfs ]
+
+if args.distros != 'all' and args.distros != '':
+    distros2 = args.distros.split(",")
+    distros2 = [ x.strip() for x in distros2 ]
+    distros = [ x for x in distros2 if x in distros ]
+
+print(json.dumps(distros))


### PR DESCRIPTION
This is something that we can trigger manually, to see how the build works on Linux.

Alpine 3.19 and Alpine edge fail currently because they fail to build arrow. I still kept them, they might work with future arrow versions.