### PR TITLE
Tweak for arm64 on Window

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -19,7 +19,7 @@ endif
 
 PKG_LIBS=-L$(RWINLIB)/lib \
 	-lgrpc++ -lgrpc -laddress_sorting -lre2 -lupb -lcares -lz -lgpr -lssl -lcrypto -lprotobuf \
-	$(ABSL_LIBS) -ldbghelp -lws2_32 -lgdi32 -lcrypt32 -lbcrypt -ldbghelp -liphlpapi -ladvapi32
+	$(ABSL_LIBS) -pthread -ldbghelp -lws2_32 -lgdi32 -lcrypt32 -lbcrypt -ldbghelp -liphlpapi -ladvapi32
 
 BINDIR=$(RWINLIB)/bin$(subst 64,,$(WIN))
 


### PR DESCRIPTION
We need to add this flag to make the build succeed on arm64 for Windows (which may or may not be supported some time in the future).