### PR TITLE
GHA: do not test on macOS-11

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # macos-11 is no longer supported by homebrew:
-          - { os: macos-11,       r: 'release' }
           - { os: macos-12,       r: 'release' }
           - { os: macos-13,       r: 'release' }
           - { os: macos-13,       r: 'release', deps: 'homebrew' }


### PR DESCRIPTION
GHA does not seem to have any macOS-11 runners
nowadays.