### PR TITLE
fix #86, int64 payload converted too soon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# bigrquerystorage (development version)
+
+* `bqs_table_download()` no longer converts INT64 columns through R's double,
+  which silently lost precision for values above 2^53 before the `bigint`
+  argument was applied. INT64 columns (including fields nested in RECORD
+  columns) are now read directly as `bit64::integer64`, so
+  `bigint = "integer64"` and `bigint = "character"` are lossless over the full
+  64-bit range (r-dbi/bigrquery#689). REPEATED INT64 columns still go through
+  double due to a conversion bug in nanoarrow, but now honor `bigint`.
+
 # bigrquerystorage 1.2.2
 
 * Fix logging for new version of gRPC.

--- a/R/bqs_download.R
+++ b/R/bqs_download.R
@@ -111,7 +111,9 @@ bqs_table_download <- function(
 
   rlang::local_options(nanoarrow.warn_unregistered_extension = FALSE)
   fields <- select_fields(bigrquery::bq_table_fields(x), selected_fields)
-  tb <- parse_postprocess(tibble::tibble(as.data.frame(nanoarrow::read_nanoarrow(raws))), bigint, fields)
+  stream <- nanoarrow::read_nanoarrow(raws)
+  to <- int64_ptype(stream$get_schema())
+  tb <- parse_postprocess(tibble::tibble(nanoarrow::convert_array_stream(stream, to = to)), bigint, fields)
 
   # Batches do not support a n_max so we get just enough results before
   # exiting the streaming loop.
@@ -228,20 +230,37 @@ bqs_initiate <- function() {
 
 # utils ------------------------------------------------------------------
 
+#' Build a conversion target for a nanoarrow stream where every int64 column,
+#' including those nested in structs, becomes a bit64::integer64 instead of the
+#' lossy double that the default conversion produces. See
+#' https://github.com/r-dbi/bigrquery/issues/689. int64 fields nested under
+#' list types (REPEATED columns) are left at the inferred double because
+#' nanoarrow (<= 0.8.0.1) converts int64-under-list to integer64 incorrectly.
+#' @noRd
+int64_ptype <- function(schema, ptype = nanoarrow::infer_nanoarrow_ptype(schema)) {
+  if (identical(schema$format, "l")) {
+    bit64::integer64()
+  } else if (is.data.frame(ptype)) {
+    ptype[] <- mapply(int64_ptype, schema$children, ptype, SIMPLIFY = FALSE)
+    ptype
+  } else {
+    ptype
+  }
+}
+
 #' @noRd
 parse_postprocess <- function(df, bigint, fields) {
   tests <- list()
-  if (bigint != "numeric") {
-    as_bigint <- switch(bigint,
-      integer = as.integer,
-      integer64 = bit64::as.integer64,
-      character = as.character
-    )
-    tests[["bigint"]] <- list(
-    	"test" = function(x,y) is.numeric(x) & y[["type"]] %in% c("INT", "SMALLINT", "INTEGER", "BIGINT", "TINYINT", "BYTEINT", "INT64"),
-    	"func" = function(x) as_bigint(x)
-    )
-  }
+  as_bigint <- switch(bigint,
+    integer = as.integer,
+    integer64 = bit64::as.integer64,
+    numeric = as.numeric,
+    character = as.character
+  )
+  tests[["bigint"]] <- list(
+  	"test" = function(x,y) y[["type"]] %in% c("INT", "SMALLINT", "INTEGER", "BIGINT", "TINYINT", "BYTEINT", "INT64"),
+  	"func" = function(x) as_bigint(x)
+  )
 	if (has_type(fields, "DATETIME")) {
 		tests[["DATETIME"]] <- list(
 			"test" = function(x,y) {y[["type"]] %in% "DATETIME"},

--- a/tests/testthat/test-bigint.R
+++ b/tests/testthat/test-bigint.R
@@ -1,0 +1,57 @@
+# int64 handling ---------------------------------------------------------
+
+test_that("int64_ptype maps int64 to integer64, including struct fields", {
+  schema <- na_struct(list(
+    a = na_int64(),
+    b = na_string(),
+    c = na_struct(list(d = na_int64()))
+  ))
+  ptype <- int64_ptype(schema)
+  expect_s3_class(ptype$a, "integer64")
+  expect_type(ptype$b, "character")
+  expect_s3_class(ptype$c$d, "integer64")
+})
+
+test_that("int64_ptype leaves list fields at the inferred type", {
+  # nanoarrow (<= 0.8.0.1) converts int64-under-list to integer64 incorrectly,
+  # so REPEATED columns keep the default (double) conversion
+  schema <- na_struct(list(a = na_list(na_int64())))
+  ptype <- int64_ptype(schema)
+  expect_type(attr(ptype$a, "ptype"), "double")
+})
+
+test_that("int64 conversion is lossless (r-dbi/bigrquery#689)", {
+  big <- bit64::as.integer64("9223372036854775295")
+  arr <- as_nanoarrow_array(
+    data.frame(x = big),
+    schema = na_struct(list(x = na_int64()))
+  )
+  fields <- list(list(name = "x", type = "INT64", mode = "NULLABLE"))
+
+  convert <- function(bigint) {
+    stream <- basic_array_stream(list(arr))
+    df <- convert_array_stream(stream, to = int64_ptype(stream$get_schema()))
+    parse_postprocess(tibble::tibble(df), bigint, fields)
+  }
+
+  expect_identical(convert("integer64")$x, big)
+  expect_identical(convert("character")$x, "9223372036854775295")
+  expect_identical(suppressWarnings(convert("integer")$x), NA_integer_)
+  expect_identical(
+    suppressWarnings(convert("numeric")$x),
+    suppressWarnings(as.numeric(big))
+  )
+})
+
+test_that("repeated int64 columns honor bigint", {
+  arr <- as_nanoarrow_array(list(1:2, 3L), schema = na_list(na_int64()))
+  stream <- basic_array_stream(list(arr))
+  x <- convert_array_stream(stream, to = int64_ptype(stream$get_schema()))
+  fields <- list(list(name = "x", type = "INT64", mode = "REPEATED"))
+
+  df64 <- parse_postprocess(tibble::tibble(x = x), "integer64", fields)
+  expect_s3_class(df64$x[[1]], "integer64")
+
+  dfint <- parse_postprocess(tibble::tibble(x = x), "integer", fields)
+  expect_identical(dfint$x, list(1:2, 3L))
+})


### PR DESCRIPTION
- add `int64_ptype()` as a helper for nanoarrow stream with int64 content
- `is.numeric(x) &` removed because with a list this is always false
- add unit-tests